### PR TITLE
fix: simplify condition syntax for Render deploy hook and health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,11 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/mainVPCO'
     steps:
       - name: Trigger Render deploy hook
-        if: ${{ secrets.RENDER_DEPLOY_HOOK_URL != '' }}
+        if: secrets.RENDER_DEPLOY_HOOK_URL != ''
         run: |
           curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK_URL }}" -o /dev/null
       - name: Wait for deployment (optional health check)
-        if: ${{ secrets.RENDER_HEALTHCHECK_URL != '' }}
+        if: secrets.RENDER_HEALTHCHECK_URL != ''
         run: |
           echo "Waiting for deployment to become healthy..."
           for i in {1..30}; do


### PR DESCRIPTION
## Summary by Sourcery

Simplify the conditional syntax in the GitHub Actions deploy workflow by removing interpolation from the secret checks for the Render deploy hook and health check steps.

CI:
- Use direct expression syntax (secrets.SECRET_NAME != '') instead of ${{ }} for evaluating secret presence in the deploy hook step.
- Apply the same simplified condition syntax for the optional Render health check step.